### PR TITLE
Declare netty as already provided

### DIFF
--- a/LabyMod-Tab/pom.xml
+++ b/LabyMod-Tab/pom.xml
@@ -82,6 +82,7 @@
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
             <version>4.1.65.Final</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Reduces jar file size - netty is already included in spigot environments